### PR TITLE
[DO NOT UPSTREAM] Add support for ssh_keylog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 ssh_host_ed25519_key
+ssh_keylog


### PR DESCRIPTION
This allows decrypting SSH traffic in Wireshark, which will likely be useful during debugging.