### PR TITLE
Disable CI schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: ['main']
   pull_request:
-  schedule:
-    - cron: "34 6 * * 5"
 
 jobs:
   test:


### PR DESCRIPTION
As I'm the last person to push to the main branch, I'm getting a CI failure notification every week.